### PR TITLE
Fix required multiselect fields

### DIFF
--- a/edumanage/models.py
+++ b/edumanage/models.py
@@ -47,13 +47,11 @@ class MultiSelectFormField(forms.MultipleChoiceField):
     def __init__(self, *args, **kwargs):
         supercls = super(MultiSelectFormField, self)
         # remove TypedChoiceField extra args
-        supercls_init_args = signature(supercls.__init__).parameters
-        if 'self' in supercls_init_args:
-            supercls_init_args.pop('self', None)
+        banned_args = ['self','coerce','empty_value']
         supercls.__init__(
             *args,
             **{key: val for (key, val) in kwargs.items()
-               if key in supercls_init_args}
+               if key not in banned_args}
         )
 
 class MultiSelectField(models.Field):


### PR DESCRIPTION
Hi Team, as mentioned this bug looks to be introduced due to changes in the signature of init in djangos ChoiceField. 

This change restores the previous behavior, I chose to explicitly blacklist the known bad arguments as the failure path here is much more obvious if this breaks again in the future.

I've tested this in my local instance with a small amount of data.